### PR TITLE
[Refactor] 테이블 row 클릭시 데이터전달 로직 수정

### DIFF
--- a/react_frontend/src/Table.js
+++ b/react_frontend/src/Table.js
@@ -71,10 +71,8 @@ export default function CustomizedTables({
     const handleRowClick = (index) => {
         if(variant === 'default') {
             const newSelectedRow = index === selectedRow ? null : index;
-            console.log(newSelectedRow)
             setSelectedRow(newSelectedRow); // 같은 행 클릭 시 선택 해제
-            
-            newSelectedRow === null ? onRowClick(null) : onRowClick(data[newSelectedRow]);
+            onRowClick(data[newSelectedRow]);
         }
         if(variant === 'checkbox') {
             const addRow = (selectedRows) =>

--- a/react_frontend/src/Table.js
+++ b/react_frontend/src/Table.js
@@ -70,8 +70,11 @@ export default function CustomizedTables({
 
     const handleRowClick = (index) => {
         if(variant === 'default') {
-            setSelectedRow(index === selectedRow ? null : index); // 같은 행 클릭 시 선택 해제
-            onRowClick(data[index]);
+            const newSelectedRow = index === selectedRow ? null : index;
+            console.log(newSelectedRow)
+            setSelectedRow(newSelectedRow); // 같은 행 클릭 시 선택 해제
+            
+            newSelectedRow === null ? onRowClick(null) : onRowClick(data[newSelectedRow]);
         }
         if(variant === 'checkbox') {
             const addRow = (selectedRows) =>

--- a/react_frontend/src/TableCustom.js
+++ b/react_frontend/src/TableCustom.js
@@ -88,7 +88,12 @@ export function TableCustomDoubleClickEdit({
                 return false;                       // 수정 중에는 삭제 버튼의 onRowClick 이벤트 비활성화
             }
             else {
-                return selectedRows.length > 0;     // 선택된 row가 있으면 delete 버튼 활성화
+                if(selectedRows.includes(null)) {
+                    return false;
+                }
+                else {
+                    return selectedRows.length > 0;     // 선택된 row가 있으면 delete 버튼 활성화
+                }
             }
         }
         return true;  // 'Add' 버튼은 항상 활성화
@@ -139,7 +144,6 @@ export function TableCustomDoubleClickEdit({
                     buttonStatus={buttonStatus}
                     isEditing={isEditing}       //for edit button
                 />
-                {console.log("buttonStatus" + buttonStatus)}
                 
                 {modals.map((modal) => {
                     const ModalComponent = modalMap[modal.modalType];

--- a/react_frontend/src/TableCustom.js
+++ b/react_frontend/src/TableCustom.js
@@ -32,19 +32,10 @@ export default function TableCustom({
     table = true,
     selectedRows = [],       // 테이블에서 선택된 row 리스트
 }) {
-    const [isEditing, setIsEditing] = useState(false); // 'Edit' 모드 상태 관리
-    const [editableData, setEditableData] = useState(data); // 수정된 데이터 저장
-    const [editingCell, setEditingCell] = useState({ row: null, col: null }); // 현재 편집 중인 셀
-    
     // 버튼 활성화 상태 결정
     const buttonStatus = buttons.map((button) => {
-        if (button === 'Delete') {
-            if(isEditing) {
-                return false;                       // 수정 중에는 삭제 버튼의 onRowClick 이벤트 비활성화
-            }
-            else {
-                return selectedRows.length > 0;     // 선택된 row가 있으면 delete 버튼 활성화
-            }
+        if (button === 'Edit' || button === 'Delete') {
+            return selectedRows.length > 0;     // 선택된 row가 있으면 delete 버튼 활성화
         }
         return true;  // 'Add' 버튼은 항상 활성화
     });

--- a/react_frontend/src/TableCustom.js
+++ b/react_frontend/src/TableCustom.js
@@ -32,10 +32,19 @@ export default function TableCustom({
     table = true,
     selectedRows = [],       // 테이블에서 선택된 row 리스트
 }) {
+    const [isEditing, setIsEditing] = useState(false); // 'Edit' 모드 상태 관리
+    const [editableData, setEditableData] = useState(data); // 수정된 데이터 저장
+    const [editingCell, setEditingCell] = useState({ row: null, col: null }); // 현재 편집 중인 셀
+    
     // 버튼 활성화 상태 결정
     const buttonStatus = buttons.map((button) => {
-        if (button === 'Edit' || button === 'Delete') {
-            return selectedRows.length > 0;
+        if (button === 'Delete') {
+            if(isEditing) {
+                return false;                       // 수정 중에는 삭제 버튼의 onRowClick 이벤트 비활성화
+            }
+            else {
+                return selectedRows.length > 0;     // 선택된 row가 있으면 delete 버튼 활성화
+            }
         }
         return true;  // 'Add' 버튼은 항상 활성화
     });
@@ -84,7 +93,12 @@ export function TableCustomDoubleClickEdit({
     // 버튼 활성화 상태 결정
     const buttonStatus = buttons.map((button) => {
         if (button === 'Delete') {
-            return !isEditing && selectedRows.length > 0;   // 수정 중에는 삭제 버튼의 onRowClick 이벤트 비활성화
+            if(isEditing) {
+                return false;                       // 수정 중에는 삭제 버튼의 onRowClick 이벤트 비활성화
+            }
+            else {
+                return selectedRows.length > 0;     // 선택된 row가 있으면 delete 버튼 활성화
+            }
         }
         return true;  // 'Add' 버튼은 항상 활성화
     });
@@ -134,6 +148,7 @@ export function TableCustomDoubleClickEdit({
                     buttonStatus={buttonStatus}
                     isEditing={isEditing}       //for edit button
                 />
+                {console.log("buttonStatus" + buttonStatus)}
                 
                 {modals.map((modal) => {
                     const ModalComponent = modalMap[modal.modalType];

--- a/react_frontend/src/assets/json/searchFormData.js
+++ b/react_frontend/src/assets/json/searchFormData.js
@@ -149,7 +149,8 @@ export const formField_pg = [
         {value: '16', label: '경남'},
         {value: '17', label: '경북 포항시'},
         {value: '18', label: '세종시'},
-    ]}
+    ]},
+    { type: 'SelectCalendar', name: 'calendar', label: '조회기간' }
 ]
 
 export const formField_fl = [

--- a/react_frontend/src/components/fieldinfo/facility/Fad.js
+++ b/react_frontend/src/components/fieldinfo/facility/Fad.js
@@ -48,7 +48,7 @@ export default function Fad() {
             
             <SearchForms onFormSubmit={handleFormSubmit} formFields={formField_fad} onSearch={handleSearch} />
             
-            {(!formData || Object.keys(formData).length === 0) ?
+            {showResults ?
             <></> : ( //TODO: 백엔드에서 받아온 값으로 바꾸기(data 파라미터)
                 <>
                     <div className={tableStyles.table_title}>조회결과</div>

--- a/react_frontend/src/components/fieldinfo/facility/Fam.js
+++ b/react_frontend/src/components/fieldinfo/facility/Fam.js
@@ -14,9 +14,10 @@ export default function Fam() {
     const handleFormSubmit = (data) => {
         setFormData(data);
     };
+
     // 활동자료 목록 row 클릭 시 호출될 함수
-    const handleActvClick = (row) => {
-        setSelectedActv(row.ActvDataName);
+    const handleActvClick = (actv) => {
+        setSelectedActv(actv?.actvDataName ?? null);
     };
 
     const showModal = () => {

--- a/react_frontend/src/components/fieldinfo/facility/Fl.js
+++ b/react_frontend/src/components/fieldinfo/facility/Fl.js
@@ -1,13 +1,13 @@
 import React, { useState } from "react";
 import * as tableStyles from "../../../assets/css/newTable.css";
-import TableCustom, {TableCustomDoubleClickEdit} from "../../../TableCustom";
+import{TableCustomDoubleClickEdit} from "../../../TableCustom";
 import SearchForms from "../../../SearchForms";
 import {lib} from "../../../assets/json/selectedPjt";
 import {formField_fl} from "../../../assets/json/searchFormData.js";
 
 export default function Fl() {
     const [formData, setFormData] = useState({});                 // 검색 데이터
-    const [selectedEqLibs, setSelectedEqLibs] = useState([]);     // 선택된 설비 LIB 목록(PK column only)
+    const [selectedEqLib, setSelectedEqLib] = useState(null);     // 선택된 설비 LIB 목록(PK column only)
     const [isModalOpen, setIsModalOpen] = useState({
         FlAdd: false,
         Del: false
@@ -20,7 +20,7 @@ export default function Fl() {
 
     // 설비LIB row 클릭 시 호출될 함수
     const handleEqLibClick = (lib) => {
-        setSelectedEqLibs(lib.map(item => item.EquipName));
+        setSelectedEqLib(lib?.EquipName ?? null);
     };
 
     // 모달 열기
@@ -62,7 +62,7 @@ export default function Fl() {
                         buttons={['Edit', 'Delete', 'Add']}
                         onClicks={[()=>{}, onDeleteClick, onAddClick]}
                         onRowClick={(e) => handleEqLibClick(e)}
-                        selectedRows={selectedEqLibs}
+                        selectedRows={[selectedEqLib]}
                         modals={[
                             {
                                 'modalType': 'Del',

--- a/react_frontend/src/components/fieldinfo/facility/Fl.js
+++ b/react_frontend/src/components/fieldinfo/facility/Fl.js
@@ -58,7 +58,6 @@ export default function Fl() {
                 <>
                     <TableCustomDoubleClickEdit 
                         title='설비LIB목록' 
-                        variant='checkbox'
                         data={lib}                   
                         buttons={['Edit', 'Delete', 'Add']}
                         onClicks={[()=>{}, onDeleteClick, onAddClick]}

--- a/react_frontend/src/components/fieldinfo/project/Pd.js
+++ b/react_frontend/src/components/fieldinfo/project/Pd.js
@@ -11,8 +11,7 @@ export default function Pd() {
     const [searchedPjt, setSearchedPjt] = useState(null);             // 프로젝트 찾기 결과(api 연동해서 받아올 data)
     const [formData, setFormData] = useState({});                     // 검색 데이터
     const [searchResult, setsearchResult] = useState(null);           // 프로젝트 조회 결과(api 연동해서 받아올 data)
-    const [selectedManager, setSelectedManager] = useState([]);       // 선택한 담당자
-
+    const [selectedManager, setSelectedManager] = useState(null);       // 선택한 담당자
     // 선택된 담당자들(PK column only)
     const [isModalOpen, setIsModalOpen] = useState({
         PdAdd: false,
@@ -26,7 +25,7 @@ export default function Pd() {
     
     // 담당자 row 클릭 시 호출될 함수
     const handleManagerClick = (manager) => {
-        setSelectedManager(manager.loginId);
+        manager === null ? setSelectedManager(null) : setSelectedManager(manager.loginId);
     };
 
     // 모달 열기
@@ -65,14 +64,13 @@ export default function Pd() {
                 <>
                     <div className={tableStyles.table_title}>조회결과</div>
                     <Table data={project} />                    
-                    {console.log("selectedManager: " + selectedManager)}
-                    <TableCustom
+                    <TableCustomDoubleClickEdit
                         title='담당자목록' 
                         data={managers}                   
                         buttons={['Delete', 'Add']}
                         onClicks={[onDeleteClick, onAddClick]}
                         onRowClick={handleManagerClick}
-                        selectedRows={selectedManager.length === 0 ? [] : [selectedManager]}
+                        selectedRows={selectedManager === null ? [] : [selectedManager]}
                         modals={[
                             {
                                 'modalType': 'Del',

--- a/react_frontend/src/components/fieldinfo/project/Pd.js
+++ b/react_frontend/src/components/fieldinfo/project/Pd.js
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import * as tableStyles from "../../../assets/css/newTable.css";
 import Table from "../../../Table";
-import TableCustom, {TableCustomDoubleClickEdit} from "../../../TableCustom";
+import {TableCustomDoubleClickEdit} from "../../../TableCustom";
 import project from "../../../assets/json/selectedPjt";
 import managers from "../../../assets/json/manager";
 import SearchForms from "../../../SearchForms";
@@ -11,8 +11,7 @@ export default function Pd() {
     const [searchedPjt, setSearchedPjt] = useState(null);             // 프로젝트 찾기 결과(api 연동해서 받아올 data)
     const [formData, setFormData] = useState({});                     // 검색 데이터
     const [searchResult, setsearchResult] = useState(null);           // 프로젝트 조회 결과(api 연동해서 받아올 data)
-    const [selectedManager, setSelectedManager] = useState(null);       // 선택한 담당자
-    // 선택된 담당자들(PK column only)
+    const [selectedManager, setSelectedManager] = useState(null);     // 선택된 담당자들(PK column only)
     const [isModalOpen, setIsModalOpen] = useState({
         PdAdd: false,
         Del: false
@@ -25,7 +24,7 @@ export default function Pd() {
     
     // 담당자 row 클릭 시 호출될 함수
     const handleManagerClick = (manager) => {
-        manager === null ? setSelectedManager(null) : setSelectedManager(manager.loginId);
+        setSelectedManager(manager?.loginId ?? null);
     };
 
     // 모달 열기
@@ -70,7 +69,7 @@ export default function Pd() {
                         buttons={['Delete', 'Add']}
                         onClicks={[onDeleteClick, onAddClick]}
                         onRowClick={handleManagerClick}
-                        selectedRows={selectedManager === null ? [] : [selectedManager]}
+                        selectedRows={[selectedManager]}
                         modals={[
                             {
                                 'modalType': 'Del',

--- a/react_frontend/src/components/fieldinfo/project/Pd.js
+++ b/react_frontend/src/components/fieldinfo/project/Pd.js
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import * as tableStyles from "../../../assets/css/newTable.css";
 import Table from "../../../Table";
-import TableCustom from "../../../TableCustom";
+import TableCustom, {TableCustomDoubleClickEdit} from "../../../TableCustom";
 import project from "../../../assets/json/selectedPjt";
 import managers from "../../../assets/json/manager";
 import SearchForms from "../../../SearchForms";
@@ -11,8 +11,8 @@ export default function Pd() {
     const [searchedPjt, setSearchedPjt] = useState(null);             // 프로젝트 찾기 결과(api 연동해서 받아올 data)
     const [formData, setFormData] = useState({});                     // 검색 데이터
     const [searchResult, setsearchResult] = useState(null);           // 프로젝트 조회 결과(api 연동해서 받아올 data)
-    const [selectedManagers, setSelectedManagers] = useState([]);
-    
+    const [selectedManager, setSelectedManager] = useState([]);       // 선택한 담당자
+
     // 선택된 담당자들(PK column only)
     const [isModalOpen, setIsModalOpen] = useState({
         PdAdd: false,
@@ -26,16 +26,7 @@ export default function Pd() {
     
     // 담당자 row 클릭 시 호출될 함수
     const handleManagerClick = (manager) => {
-        setSelectedManagers((prevSelectedManager) => {
-            // 선택된 사원의 loginId가 이미 배열에 존재하는지 확인
-            if (prevSelectedManager.includes(manager.loginId)) {
-                // 존재한다면 배열에서 제거
-                return prevSelectedManager.filter((id) => id !== manager.loginId);
-            } else {
-                // 존재하지 않는다면 배열에 추가
-                return [...selectedManagers, manager.loginId];
-            }
-        });
+        setSelectedManager(manager.loginId);
     };
 
     // 모달 열기
@@ -59,6 +50,7 @@ export default function Pd() {
     const onAddClick = () => {
         showModal('PdAdd');
     };
+
     const onDeleteClick = () => {
         showModal('Del');
     };
@@ -73,14 +65,14 @@ export default function Pd() {
                 <>
                     <div className={tableStyles.table_title}>조회결과</div>
                     <Table data={project} />                    
-
-                    <TableCustom 
+                    {console.log("selectedManager: " + selectedManager)}
+                    <TableCustom
                         title='담당자목록' 
-                        variant='checkbox'
                         data={managers}                   
                         buttons={['Delete', 'Add']}
                         onClicks={[onDeleteClick, onAddClick]}
                         onRowClick={handleManagerClick}
+                        selectedRows={selectedManager.length === 0 ? [] : [selectedManager]}
                         modals={[
                             {
                                 'modalType': 'Del',

--- a/react_frontend/src/components/fieldinfo/project/Pg.js
+++ b/react_frontend/src/components/fieldinfo/project/Pg.js
@@ -1,13 +1,13 @@
 import React, { useState } from "react";
 import * as tableStyles from "../../../assets/css/newTable.css"
-import TableCustom from "../../../TableCustom";
+import {TableCustomDoubleClickEdit} from "../../../TableCustom";
 import project from "../../../assets/json/project.js";
 import SearchForms from "../../../SearchForms"
 import {formField_pg} from "../../../assets/json/searchFormData.js"
 
 export default function Pg() {
-    const [formData, setFormData] = useState({});                 // 검색 데이터
-    const [selectedPjts, setSelectedPjts] = useState([]);     // 선택된 설비 LIB 목록(PK column only)
+    const [formData, setFormData] = useState({});           // 검색 데이터
+    const [selectedPjt, setSelectedPjt] = useState();     // 선택된 설비 LIB 목록(PK column only)
 
     const [isModalOpen, setIsModalOpen] = useState({
         PgAdd: false,
@@ -21,7 +21,7 @@ export default function Pg() {
 
     // 설비LIB row 클릭 시 호출될 함수
     const handlePjtClick = (pjt) => {
-        setSelectedPjts(pjt.map(item => item.PjtCode));
+        setSelectedPjt(pjt.map(item => item.PjtCode));
     };
 
     // 모달 열기
@@ -57,12 +57,13 @@ export default function Pg() {
             {(!formData || Object.keys(formData).length === 0) ?
             <></> : ( //TODO: 백엔드에서 받아온 값으로 바꾸기(Table 컴포넌트의 data 파라미터)
                 <>
-                    <TableCustom 
+                    <TableCustomDoubleClickEdit 
                         title='프로젝트목록' 
                         data={lib}                   
                         buttons={['Edit', 'Delete', 'Add']}
                         onClicks={[()=>{}, onDeleteClick, onAddClick]}
                         onRowClick={handlePjtClick}
+                        selectedRows={selectedPjt === null ? [] : [selectedPjt]}
                         modals={[
                             {
                                 'modalType': 'Del',

--- a/react_frontend/src/components/fieldinfo/project/Pg.js
+++ b/react_frontend/src/components/fieldinfo/project/Pg.js
@@ -7,55 +7,76 @@ import {formField_pg} from "../../../assets/json/searchFormData.js"
 
 export default function Pg() {
     const [formData, setFormData] = useState({});                 // 검색 데이터
-    const [selectedPjt, setSelectedPjt] = useState(null);       // 선택된 프로젝트
-    const [isModalOpen, setIsModalOpen] = useState(false);
-    const [inputValue, setInputValue] = useState("");
+    const [selectedPjts, setSelectedPjts] = useState([]);     // 선택된 설비 LIB 목록(PK column only)
+
+    const [isModalOpen, setIsModalOpen] = useState({
+        PgAdd: false,
+        Del: false
+    });
 
     //조회 버튼 클릭시 호출될 함수
     const handleFormSubmit = (data) => {
         setFormData(data);
     };
 
-    // 프로젝트 row 클릭 시 호출될 함수
-    const handlePjtClick = (row) => {
-        setSelectedPjt(row.PjtCode);   // 클릭된 프로젝트의 코드로 상태를 설정
+    // 설비LIB row 클릭 시 호출될 함수
+    const handlePjtClick = (pjt) => {
+        setSelectedPjts(pjt.map(item => item.PjtCode));
     };
 
-    const showModal = () => {
-        setIsModalOpen(true);
+    // 모달 열기
+    const showModal = (modalType) => {
+        setIsModalOpen(prevState => ({ ...prevState, [modalType]: true }));
     };
 
-    // 모달 저장 버튼 눌렀을 때 호출될 함수
-    const handleOk = (data) => {
-        setIsModalOpen(false);
-        setInputValue(data);
+    // 프로젝트 등록 버튼 클릭 시 호출될 함수
+    const handleOk = (modalType) => (data) => {
+        setIsModalOpen(prevState => ({ ...prevState, [modalType]: false })); //모달 닫기
+        //setInputValue(data);
     };
 
-    const handleCancel = () => {
-        setIsModalOpen(false);
-    }; 
+    // 모달 닫기
+    const handleCancel = (modalType) => () => {
+        setIsModalOpen(prevState => ({ ...prevState, [modalType]: false }));
+    };
+
+    // 버튼 클릭 시 모달 열림 설정
+    const onAddClick = () => {
+        showModal('PgAdd');
+    };
+
+    const onDeleteClick = () => {
+        showModal('Del');
+    };
 
     return (
         <>
             <div className={tableStyles.menu}>현장정보 &gt; 프로젝트 &gt; 프로젝트 관리</div>
-            
             <SearchForms onFormSubmit={handleFormSubmit} formFields={formField_pg} />
             
             {(!formData || Object.keys(formData).length === 0) ?
-            <></> : ( //TODO: 백엔드에서 받아온 값으로 바꾸기(data 파라미터)
+            <></> : ( //TODO: 백엔드에서 받아온 값으로 바꾸기(Table 컴포넌트의 data 파라미터)
                 <>
                     <TableCustom 
                         title='프로젝트목록' 
-                        data={project} 
+                        data={lib}                   
                         buttons={['Edit', 'Delete', 'Add']}
+                        onClicks={[()=>{}, onDeleteClick, onAddClick]}
                         onRowClick={handlePjtClick}
-                        modal={{
-                            'modalType': 'PD',
-                            'buttonClick': showModal,
-                            'isModalOpen': isModalOpen,
-                            'handleOk': handleOk,
-                            'handleCancel': handleCancel
-                        }}
+                        modals={[
+                            {
+                                'modalType': 'Del',
+                                'isModalOpen': isModalOpen.Del,
+                                'handleOk': handleOk('Del'),
+                                'handleCancel': handleCancel('Del')
+                            },
+                            {
+                                'modalType': 'FlAdd',
+                                'isModalOpen': isModalOpen.FlAdd,
+                                'handleOk': handleOk('FlAdd'),
+                                'handleCancel': handleCancel('FlAdd')
+                            }
+                        ]}
                     />
                 </>
             )}

--- a/react_frontend/src/components/fieldinfo/project/Rm.js
+++ b/react_frontend/src/components/fieldinfo/project/Rm.js
@@ -73,7 +73,6 @@ export default function Rm() {
 
                     <TableCustomDoubleClickEdit 
                         title='매출액목록' 
-                        variant='checkbox'
                         data={saleAmt}                   
                         buttons={['Delete', 'Edit', 'Add']}
                         onClicks={[onDeleteClick, () => {}, onAddClick]}

--- a/react_frontend/src/components/fieldinfo/project/Rm.js
+++ b/react_frontend/src/components/fieldinfo/project/Rm.js
@@ -10,7 +10,7 @@ export default function Rm() {
     const [searchedPjt, setSearchedPjt] = useState(null);             // 프로젝트 찾기 결과(api 연동해서 받아올 data)
     const [formData, setFormData] = useState({});                     // 검색 데이터
     const [searchResult, setsearchResult] = useState(null);           // 프로젝트 조회 결과(api 연동해서 받아올 data)
-    const [selectedSAs, setSelectedSAs] = useState([]);   
+    const [selectedSA, setSelectedSA] = useState();   
     const [isModalOpen, setIsModalOpen] = useState({
         RmAdd: false,
         Del: false
@@ -23,16 +23,7 @@ export default function Rm() {
 
     // 매출액 row 클릭 시 호출될 함수
     const handleSAClick = (saleAmt) => {
-        setSelectedSAs((prevSelectedSA) => {
-            // 선택된 사원의 loginId가 이미 배열에 존재하는지 확인
-            if (prevSelectedSA.includes(saleAmt.saleAmt)) {
-                // 존재한다면 배열에서 제거
-                return prevSelectedSA.filter((id) => id !== saleAmt.saleAmt);
-            } else {
-                // 존재하지 않는다면 배열에 추가
-                return [...selectedSAs, saleAmt.saleAmt];
-            }
-        });
+        saleAmt === null ? setSelectedSA(null) : setSelectedSA(saleAmt.saleAmt);
     };
 
     // 모달 열기
@@ -77,7 +68,7 @@ export default function Rm() {
                         buttons={['Delete', 'Edit', 'Add']}
                         onClicks={[onDeleteClick, () => {}, onAddClick]}
                         onRowClick={handleSAClick}
-                        selectedRows={selectedSAs}
+                        selectedRows={selectedSA === null ? [] : [selectedSA]}
                         modals={[
                             {
                                 'modalType': 'Del',

--- a/react_frontend/src/components/fieldinfo/project/Rm.js
+++ b/react_frontend/src/components/fieldinfo/project/Rm.js
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import * as tableStyles from "../../../assets/css/newTable.css"
 import Table from "../../../Table";
-import TableCustom, {TableCustomDoubleClickEdit} from "../../../TableCustom";
+import {TableCustomDoubleClickEdit} from "../../../TableCustom";
 import {pjt, saleAmt} from "../../../assets/json/selectedPjt";
 import SearchForms from "../../../SearchForms";
 import {formField_ps12} from "../../../assets/json/searchFormData.js";
@@ -10,7 +10,7 @@ export default function Rm() {
     const [searchedPjt, setSearchedPjt] = useState(null);             // 프로젝트 찾기 결과(api 연동해서 받아올 data)
     const [formData, setFormData] = useState({});                     // 검색 데이터
     const [searchResult, setsearchResult] = useState(null);           // 프로젝트 조회 결과(api 연동해서 받아올 data)
-    const [selectedSA, setSelectedSA] = useState();   
+    const [selectedSA, setSelectedSA] = useState(null);   
     const [isModalOpen, setIsModalOpen] = useState({
         RmAdd: false,
         Del: false
@@ -23,7 +23,7 @@ export default function Rm() {
 
     // 매출액 row 클릭 시 호출될 함수
     const handleSAClick = (saleAmt) => {
-        saleAmt === null ? setSelectedSA(null) : setSelectedSA(saleAmt.saleAmt);
+        setSelectedSA(saleAmt?.saleAmt ?? null);
     };
 
     // 모달 열기
@@ -53,7 +53,6 @@ export default function Rm() {
     return (
         <>
             <div className={tableStyles.menu}>현장정보 &gt; 프로젝트 &gt; 매출액 관리</div>
-            
             <SearchForms onFormSubmit={handleFormSubmit} formFields={[formField_ps12[0]]} />
             
             {(!formData || Object.keys(formData).length === 0) ?
@@ -68,7 +67,7 @@ export default function Rm() {
                         buttons={['Delete', 'Edit', 'Add']}
                         onClicks={[onDeleteClick, () => {}, onAddClick]}
                         onRowClick={handleSAClick}
-                        selectedRows={selectedSA === null ? [] : [selectedSA]}
+                        selectedRows={[selectedSA]}
                         modals={[
                             {
                                 'modalType': 'Del',

--- a/react_frontend/src/modals/PdModal.js
+++ b/react_frontend/src/modals/PdModal.js
@@ -276,7 +276,6 @@ export function CmEditModal({isModalOpen, handleOk, handleCancel}){
 
     // 등록 버튼 클릭 시 호출될 함수
     const handleSelect = () => {
-        console.log(selectedEmps);
         handleOk(selectedEmps);
     };
 
@@ -391,7 +390,6 @@ export function CmListEditModal({isModalOpen, handleOk, handleCancel}){
 
     // 등록 버튼 클릭 시 호출될 함수
     const handleSelect = () => {
-        console.log(selectedEmps);
         handleOk(selectedEmps);
     };
 


### PR DESCRIPTION
pull 받은 다음에, TableCustom 컴포넌트를 호출하는 컴포넌트(기능 화면)에서 수정해야할 목록입니다.

``` 
// row 클릭 시 호출될 함수
const handleManagerClick = (manager) => {
    setSelectedManager(manager?.loginId ?? null);
};
```

```
<TableCustomDoubleClickEdit
      title='담당자목록' 
      data={managers}                   
      buttons={['Delete', 'Add']}
      onClicks={[onDeleteClick, onAddClick]}
      onRowClick={handleManagerClick}
      selectedRows={[selectedManager]}
      modals={[
          {
              'modalType': 'Del',
              'isModalOpen': isModalOpen.Del,
              'handleOk': handleOk('Del'),
              'handleCancel': handleCancel('Del')
          },
          {
              'modalType': 'PdAdd',
              'isModalOpen': isModalOpen.PdAdd,
              'handleOk': handleOk('PdAdd'),
              'handleCancel': handleCancel('PdAdd')
          }
      ]}
  />
```
위 코드 처럼 selectedRows 파라미터 넘겨주시면 돼용
이 코드 예제는 src>components>fieldinfo>project>Pd.js 입니다. 