### PR TITLE
[Feat] TableCustom 삭제 버튼 비활성화 에러 수정

### DIFF
--- a/react_frontend/src/TableCustom.js
+++ b/react_frontend/src/TableCustom.js
@@ -35,7 +35,11 @@ export default function TableCustom({
     // 버튼 활성화 상태 결정
     const buttonStatus = buttons.map((button) => {
         if (button === 'Edit' || button === 'Delete') {
-            return selectedRows.length > 0;     // 선택된 row가 있으면 delete 버튼 활성화
+            if(selectedRows.includes(null)) {               // 선택한 row가 없으면 삭제 버튼의 onRowClick 이벤트 비활성화(variant='default')
+                return false;                               
+            } else {
+                return selectedRows.length > 0;             // 선택된 row가 있으면 delete 버튼 활성화(variant='checkbox')
+            }
         }
         return true;  // 'Add' 버튼은 항상 활성화
     });
@@ -84,16 +88,10 @@ export function TableCustomDoubleClickEdit({
     // 버튼 활성화 상태 결정
     const buttonStatus = buttons.map((button) => {
         if (button === 'Delete') {
-            if(isEditing) {
-                return false;                       // 수정 중에는 삭제 버튼의 onRowClick 이벤트 비활성화
-            }
-            else {
-                if(selectedRows.includes(null)) {
-                    return false;
-                }
-                else {
-                    return selectedRows.length > 0;     // 선택된 row가 있으면 delete 버튼 활성화
-                }
+            if(isEditing || selectedRows.includes(null)) {  // 수정 중이거나 선택한 row 가 없으면 삭제 버튼의 onRowClick 이벤트 비활성화
+                return false;                               
+            } else {
+                return selectedRows.length > 0;             // 선택된 row가 있으면 delete 버튼 활성화
             }
         }
         return true;  // 'Add' 버튼은 항상 활성화


### PR DESCRIPTION
TableuCustom.js 의 TableCustom() 에서 선택한 row가 없을 때도 삭제버튼이 활성화 돼있는 에러 발생하여 수정했습니다